### PR TITLE
修复“发生解析配置文件失败并使用默认配置”实际未生效的问题

### DIFF
--- a/rsyars.cmd/main.go
+++ b/rsyars.cmd/main.go
@@ -42,8 +42,9 @@ func main() {
 		value := new(confT)
 		if err := yaml.Unmarshal(body, value); err != nil {
 			log.Errorf("解析配置文件失败并使用默认配置 -> %+v", err)
+		} else {
+			conf = *value
 		}
-		conf = *value
 	}
 	for _, rule := range conf.Rule {
 		if rule[0] != '0' && rule[0] != '1' && rule[0] != '2' ||


### PR DESCRIPTION
按照原来的实现，如果解析yaml配置文件失败，conf将被设置为confT的默认值。